### PR TITLE
Remove dotenv invocation from twitter plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ twine
 tweepy
 pandas
 auto_gpt_plugin_template
-python-dotenv

--- a/src/autogpt_plugins/twitter/__init__.py
+++ b/src/autogpt_plugins/twitter/__init__.py
@@ -1,15 +1,10 @@
 """Twitter API integrations using Tweepy."""
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar
-from dotenv import load_dotenv
 from auto_gpt_plugin_template import AutoGPTPluginTemplate
-from pathlib import Path
 import os
 import tweepy
 
 PromptGenerator = TypeVar("PromptGenerator")
-
-with open(str(Path(os.getcwd()) / ".env"), 'r') as fp:
-    load_dotenv(stream=fp)
 
 
 class Message(TypedDict):


### PR DESCRIPTION
This is a paired fix with https://github.com/Significant-Gravitas/Auto-GPT/pull/3251 to let the Auto-GPT package handle loading of environment variables.  Plugins should not source a `.env` file themselves.