### PR TITLE
tweepy version fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ wheel
 setuptools
 build
 twine
-tweepy
+tweepy==4.13.0
 pandas
 auto_gpt_plugin_template


### PR DESCRIPTION
tweepy v4.14.0 got rid of Stream class the twitter plugin uses, pin to 4.13.0. This came up in issue #60 