### PR TITLE
Allow unzipped plugins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 /src/autogpt_plugins/email @riensen 
 /src/autogpt_plugins/scenex @delgermurun 
 /src/autogpt_plugins/bing_search @ForestLinSen
+/src/autogpt_plugins/unzipped_plugins @pr-0f3t

--- a/README.md
+++ b/README.md
@@ -11,41 +11,46 @@ Follow these steps to configure the Auto-GPT Plugins:
 
 1. **Install Auto-GPT**
 
-   If you haven't already, follow the installation instructions provided by [Auto-GPT](https://github.com/Significant-Gravitas/Auto-GPT) to install it.
+   If you haven't already, create a folder `Significant-Gravitas` and clone the [Auto-GPT](https://github.com/Significant-Gravitas/Auto-GPT) repository into the folder. Follow the installation instructions provided by [Auto-GPT](https://github.com/Significant-Gravitas/Auto-GPT).
 
-1. **Run the following to pull the plugins folder down from the `root` of `autogpt`**
+1. **Clone the Auto-GPT-Plugins repository**
 
-    To download it directly from your Auto-GPT directory, you can run this command on Linux or MacOS:
+   Clone this repository into the `Significant-Gravitas` folder as well:
+   ```
+   git clone https://github.com/Significant-Gravitas/Auto-GPT-Plugins.git
+   ```
+   You should now have two folders in your `Significant-Gravitas` folder: `Auto-GPT` and `Auto-GPT-Plugins`.
 
-    ```bash
-    curl -L -o ./plugins/Auto-GPT-Plugins.zip https://github.com/Significant-Gravitas/Auto-GPT-Plugins/archive/refs/heads/master.zip
-    ```
+1. **Install required dependencies**
 
-    In PowerShell:
+   Navigate to the Auto-GPT-Plugins folder in your terminal and execute the following command to install the necessary dependencies:
 
-    ```pwsh
-    Invoke-WebRequest -Uri "https://github.com/Significant-Gravitas/Auto-GPT-Plugins/archive/refs/heads/master.zip"     -OutFile "./plugins/Auto-GPT-Plugins.zip"
-    ```
+   - For Command Prompt:
+   ```
+   pip install -r requirements.txt
+   ```
+   
+   - For PowerShell:
+   ```
+   pip install -r .\requirements.txt
+   ```
 
-1. **Run the dependency install script for plugins**
-    You can run it with either:
-    Linux or MacOS:
+1. **Package the plugin as a Zip file**
 
-    ```bash
-    ./run.sh --install-plugin-deps
-    ```
+   Execute the following command to compress the Auto-GPT-Plugins folder and place the archive into the `Auto-GPT/plugins` folder:
 
-   Windows:
+   - For Command Prompt:
+   ```
+   zip -ru ../Auto-GPT/plugins/Auto-GPT-Plugins.zip
+   ```
+   
+   - For PowerShell:
+   ```
+   Compress-Archive -Path .\* -DestinationPath ..\Auto-GPT\plugins\Auto-GPT-Plugins.zip -Force
+   ```
 
-    ```pwsh
-   .\run.bat --install-plugin-deps
-    ```
+   Alternatively, you can manually zip the `Auto-GPT-Plugins` folder, rename it to Auto-GPT-Plugins.zip, and then paste the zip file into the `Auto-GPT/plugins/` directory.
 
-    Or directly via the CLI:
-
-    ```bash
-    python -m autogpt --install-plugin-deps
-    ````
 
 ## Plugins in the repository
 
@@ -55,8 +60,7 @@ For interactionless use, set `ALLOWLISTED_PLUGINS=example-plugin1,example-plugin
 |--------------|-----------|--------|
 | Twitter      | AutoGPT is capable of retrieving Twitter posts and other related content by accessing the Twitter platform via the v1.1 API using Tweepy.| [autogpt_plugins/twitter](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/twitter)
 | Email | Revolutionize email management with the Auto-GPT Email Plugin, leveraging AI to automate drafting and intelligent replies. | [autogpt_plugins/email](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/email)
-| SceneX | Explore image storytelling beyond pixels with the Auto-GPT SceneX Plugin. | [autogpt_plugins/scenex](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/scenex)
-| Bing Search |  This search plugin integrates Bing search engines into Auto-GPT. | [autogpt_plugins/bing_search](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/bing_search)
+| Unzipped Plugins  | *⚠️For Devs Only⚠️* This utility allows unzipped plugins to work during development. AutoGPT requires zipped plugins for enhanced security, which may slow down plugin developers.  | [autogpt_plugins/unzipped](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/unzipped)
 
 Some third-party plugins have been created by contributors that are not included in this repository. For more information about these plugins, please visit their respective GitHub pages.
 
@@ -68,10 +72,6 @@ Some third-party plugins have been created by contributors that are not included
 | MetaTrader | Connect your MetaTrader Account to Auto-GPT. | [isaiahbjork/Auto-GPT-MetaTrader-Plugin](https://github.com/isaiahbjork/Auto-GPT-MetaTrader-Plugin) |
 | Google Analytics | Connect your Google Analytics Account to Auto-GPT. | [isaiahbjork/Auto-GPT-Google-Analytics-Plugin](https://github.com/isaiahbjork/Auto-GPT-Google-Analytics-Plugin)
 | YouTube   | Various YouTube features including downloading and understanding | [jpetzke/AutoGPT-YouTube](https://github.com/jpetzke/AutoGPT-YouTube)
-| Mastodon  | Simple Mastodon plugin to send toots through a Mastodon account | [ppetermann/AutoGPTMastodonPlugin](https://github.com/ppetermann/AutoGPTMastodonPlugin)
-| TiDB Serverless   | Connect your TiDB Serverless database to Auto-GPT, enable get query results from database | [pingcap/Auto-GPT-TiDB-Serverless-Plugin](https://github.com/pingcap/Auto-GPT-TiDB-Serverless-Plugin)
-| Instagram | Instagram access | [jpetzke/AutoGPT-Instagram](https://github.com/jpetzke/AutoGPT-Instagram)
-| Crypto | Trade crypto with Auto-GPT | [isaiahbjork/Auto-GPT-Crypto-Plugin](https://github.com/isaiahbjork/Auto-GPT-Crypto-Plugin)
 
 ## Configuration
 

--- a/src/autogpt_plugins/unzipped_plugins/README.md
+++ b/src/autogpt_plugins/unzipped_plugins/README.md
@@ -1,0 +1,52 @@
+# Auto-GPT Allow Unzipped Plugins - a dev utility 🔧
+
+This utility enables faster, on-the-fly plugin testing by allowing unzipped plugins to work. 
+
+Auto-GPT requires zipped plugins for great security reasons. For some developers, zipping up plugins during the dev/test cycle slows things down. 
+
+This tool acts as a proxy between Auto-GPT's plugin API and your unzipped plugins.
+
+⚠️💀 **WARNING** 💀⚠️:
+1. Do not use this tool with plugins you are not developing.
+2. Only use this tool if your development workflow requires it.
+3. Review the code of any plugin you use thoroughly, as plugins can execute any Python code, potentially leading to malicious activities, such as stealing your API keys.
+
+## 🔧 Installation
+
+Follow these steps to configure the Auto-GPT Email Plugin:
+
+### 1. Follow Auto-GPT-Plugins Installation Instructions
+Follow the instructions as per the [Auto-GPT-Plugins/README.md](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/blob/master/README.md)
+
+### 2. Locate the `.env.template` file
+Find the file named `.env.template` in the main `/Auto-GPT` folder.
+
+### 3. Create and rename a copy of the file
+Duplicate the `.env.template` file and rename the copy to `.env` inside the `/Auto-GPT` folder.
+
+### 4. Edit the `.env` file
+Open the `.env` file in a text editor. Note: Files starting with a dot might be hidden by your operating system.
+
+### 5. Allowlist Plugin
+In your `.env` search for `ALLOWLISTED_PLUGINS` and add this Plugin:
+
+```ini
+################################################################################
+### ALLOWLISTED PLUGINS
+################################################################################
+
+#ALLOWLISTED_PLUGINS - Sets the listed plugins that are allowed (Example: plugin1,plugin2,plugin3)
+ALLOWLISTED_PLUGINS=AutoGPTAllowUnzippedPlugins
+```
+
+## Usage
+
+1. Once installed, this plugin allows Auto-GPT to call any plugin in the "Auto-GPT/plugins/" directory even if they're not zipped up.
+2. Place your plugins in the "Auto-GPT/plugins/" folder, as you normally would, except that you do not have to zip them up.
+
+## Limitations
+
+1. The plugins will not show up in Auto-GPT's plugin list, but plugin methods will be called.
+2. Currently, the plugin does not support the following methods.
+- chat_completion
+- on_planning

--- a/src/autogpt_plugins/unzipped_plugins/__init__.py
+++ b/src/autogpt_plugins/unzipped_plugins/__init__.py
@@ -1,0 +1,174 @@
+import abc
+import importlib
+import os
+from pathlib import Path
+import sys
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, TypedDict
+from auto_gpt_plugin_template import AutoGPTPluginTemplate
+
+PromptGenerator = TypeVar("PromptGenerator")
+
+
+class Message(TypedDict):
+    role: str
+    content: str
+
+
+class AutoGPTAllowUnzippedPlugins(AutoGPTPluginTemplate):
+    """
+    This plugin allows developers to use unzipped plugins simplifying the plugin development process.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._name = "Auto-GPT-Allow-Unzipped-Plugins"
+        self._version = "0.1.0"
+        self._description = "This plugin allows developers to use unzipped plugins simplifying the plugin development process."
+
+        self._plugins = self.load_unzipped_plugins()
+
+    def load_unzipped_plugins(self):
+        # Search for plugins in the plugins directory.
+        # The plugins directory is three levels up from this file.
+        unzipped_plugins = []
+        from autogpt.config.config import Config
+
+        cfg = Config()
+        plugins_dir = Path(cfg.plugins_dir)
+
+        # Find all dirs that contain a __init__.py file.
+        for path in plugins_dir.rglob("__init__.py"):
+            if "AllowUnzippedPlugins" in str(path):
+                continue
+
+            print(f"Found module '{path.name}' at: {path}")
+
+            spec = importlib.util.spec_from_file_location(path.parent.name, str(path))
+            loaded_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(loaded_module)
+            sys.modules[path.parent.name] = loaded_module
+
+            for key in dir(loaded_module):
+                if key.startswith("__"):
+                    continue
+                a_module = getattr(loaded_module, key)
+                a_keys = dir(a_module)
+                if (
+                    "_abc_impl" in a_keys
+                    and a_module.__name__ != "AutoGPTPluginTemplate"
+                ):
+                    unzipped_plugins.append(a_module())
+
+        return unzipped_plugins
+
+    def _can_handle(self, method):
+        can_handle_method = f"can_handle_{method}"
+        return any(
+            hasattr(plugin, can_handle_method) and getattr(plugin, can_handle_method)()
+            for plugin in self._plugins
+        )
+
+    def can_handle_on_response(self) -> bool:
+        return self._can_handle("on_response")
+
+    def on_response(self, response: str, *args, **kwargs) -> str:
+        for plugin in self._plugins:
+            if not plugin.can_handle_on_response():
+                continue
+            response = plugin.on_response(response, *args, **kwargs)
+        return response
+
+    def can_handle_post_prompt(self) -> bool:
+        return self._can_handle("post_prompt")
+
+    def post_prompt(self, prompt: PromptGenerator) -> PromptGenerator:
+        for plugin in self._plugins:
+            if not plugin.can_handle_post_prompt():
+                continue
+            prompt = plugin.post_prompt(prompt)
+        return prompt
+
+    def can_handle_on_planning(self) -> bool:
+        """On Planning is not supported by this plugin."""
+        return False
+
+    def on_planning(
+        self, prompt: PromptGenerator, messages: List[Message]
+    ) -> Optional[str]:
+        pass
+
+    def can_handle_post_planning(self) -> bool:
+        return self._can_handle("post_planning")
+
+    def post_planning(self, response: str) -> str:
+        for plugin in self._plugins:
+            if not plugin.can_handle_post_planning():
+                continue
+            response = plugin.post_planning(response)
+        return response
+
+    def can_handle_pre_instruction(self) -> bool:
+        return self._can_handle("pre_instruction")
+
+    def pre_instruction(self, messages: List[Message]) -> List[Message]:
+        for plugin in self._plugins:
+            if not plugin.can_handle_pre_instruction():
+                continue
+            if plugin_messages := plugin.pre_instruction(messages):
+                messages.extend(iter(plugin_messages))
+        return messages
+
+    def can_handle_on_instruction(self) -> bool:
+        return self._can_handle("on_instruction")
+
+    def on_instruction(self, messages: List[Message]) -> Optional[str]:
+        for plugin in self._plugins:
+            if not plugin.can_handle_on_instruction():
+                continue
+            if plugin_result := plugin.on_instruction(messages):
+                sep = "\n" if i else ""
+                plugins_reply = f"{plugins_reply}{sep}{plugin_result}"
+        return plugins_reply
+
+    def can_handle_post_instruction(self) -> bool:
+        return self._can_handle("post_instruction")
+
+    def post_instruction(self, response: str) -> str:
+        for plugin in self._plugins:
+            if not plugin.can_handle_post_instruction():
+                continue
+            response = plugin.post_instruction(response)
+        return response
+
+    def can_handle_pre_command(self) -> bool:
+        return self._can_handle("pre_command")
+
+    def pre_command(
+        self, command_name: str, arguments: Dict[str, Any]
+    ) -> Tuple[str, Dict[str, Any]]:
+        for plugin in self._plugins:
+            if not plugin.can_handle_pre_command():
+                continue
+            command_name, arguments = plugin.pre_command(command_name, arguments)
+        return command_name, arguments
+
+    def can_handle_post_command(self) -> bool:
+        return self._can_handle("post_command")
+
+    def post_command(self, command_name: str, response: str) -> str:
+        for plugin in self._plugins:
+            if not plugin.can_handle_post_command():
+                continue
+            result = plugin.post_command(command_name, result)
+        return result
+
+    def can_handle_chat_completion(
+        self, messages: Dict[Any, Any], model: str, temperature: float, max_tokens: int
+    ) -> bool:
+        """Not supported by this plugin."""
+        return False
+
+    def handle_chat_completion(
+        self, messages: List[Message], model: str, temperature: float, max_tokens: int
+    ) -> str:
+        pass

--- a/src/autogpt_plugins/unzipped_plugins/__init__.py
+++ b/src/autogpt_plugins/unzipped_plugins/__init__.py
@@ -31,7 +31,15 @@ class AutoGPTAllowUnzippedPlugins(AutoGPTPluginTemplate):
         # Search for plugins in the plugins directory.
         # The plugins directory is three levels up from this file.
         unzipped_plugins = []
-        from autogpt.config.config import Config
+        try:
+            from autogpt.config.config import Config
+        except ImportError:
+            if os.environ.get('TEST_MODE') == 'true':
+                # Are we im a test?
+                class Config:
+                    plugins_dir = "./"
+            else:
+                raise
 
         cfg = Config()
         plugins_dir = Path(cfg.plugins_dir)
@@ -41,7 +49,7 @@ class AutoGPTAllowUnzippedPlugins(AutoGPTPluginTemplate):
             if "AllowUnzippedPlugins" in str(path):
                 continue
 
-            print(f"Found module '{path.name}' at: {path}")
+            print(f"Found module '{path.parent.name}' at: {path}")
 
             spec = importlib.util.spec_from_file_location(path.parent.name, str(path))
             loaded_module = importlib.util.module_from_spec(spec)

--- a/src/autogpt_plugins/unzipped_plugins/test_unzipped_plugins.py
+++ b/src/autogpt_plugins/unzipped_plugins/test_unzipped_plugins.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+import importlib.util
+
+from autogpt_plugins.unzipped_plugins import AutoGPTAllowUnzippedPlugins
+
+
+def test_load_unzipped_plugins():
+    with patch("autogpt.autogpt.Path.rglob") as rglob_mock, patch(
+        "autogpt.autogpt.importlib.util.spec_from_file_location"
+    ) as spec_from_file_location_mock, patch(
+        "autogpt.autogpt.importlib.util.module_from_spec"
+    ) as module_from_spec_mock:
+        rglob_mock.return_value = [
+            Path("plugins/init.py"),
+            Path("plugins/AllowUnzippedPlugins/init.py"),
+            Path("plugins/plugin1/init.py"),
+        ]
+
+    spec_mock = MagicMock()
+    spec_from_file_location_mock.return_value = spec_mock
+
+    loaded_module_mock = MagicMock()
+    instance_mock = MagicMock()
+    loaded_module_mock.PluginClass.return_value = instance_mock
+    module_from_spec_mock.return_value = loaded_module_mock
+
+    plugin_instance = AutoGPTAllowUnzippedPlugins()
+    unzipped_plugins = plugin_instance.load_unzipped_plugins()
+    assert unzipped_plugins == [instance_mock]
+
+    rglob_mock.assert_called_once_with("__init__.py")
+    spec_from_file_location_mock.assert_called_once_with(
+        "plugin1", "plugins/plugin1/__init__.py"
+    )
+    module_from_spec_mock.assert_called_once_with(spec_mock)
+    spec_mock.loader.exec_module.assert_called_once_with(loaded_module_mock)
+    assert "plugin1" in sys.modules
+    loaded_module_mock.PluginClass.assert_called_once_with()

--- a/src/autogpt_plugins/unzipped_plugins/test_unzipped_plugins.py
+++ b/src/autogpt_plugins/unzipped_plugins/test_unzipped_plugins.py
@@ -3,38 +3,42 @@ from pathlib import Path
 import sys
 import importlib.util
 
+# We're in test mode
+import os
+os.environ['TEST_MODE'] = 'true'
+
 from autogpt_plugins.unzipped_plugins import AutoGPTAllowUnzippedPlugins
+from auto_gpt_plugin_template import AutoGPTPluginTemplate
 
 
+class TestData:
+    _abc_impl = True
+            
 def test_load_unzipped_plugins():
-    with patch("autogpt.autogpt.Path.rglob") as rglob_mock, patch(
-        "autogpt.autogpt.importlib.util.spec_from_file_location"
+    with patch("autogpt_plugins.unzipped_plugins.Path.rglob") as rglob_mock, patch(
+        "autogpt_plugins.unzipped_plugins.importlib.util.spec_from_file_location"
     ) as spec_from_file_location_mock, patch(
-        "autogpt.autogpt.importlib.util.module_from_spec"
+        "autogpt_plugins.unzipped_plugins.importlib.util.module_from_spec"
     ) as module_from_spec_mock:
         rglob_mock.return_value = [
-            Path("plugins/init.py"),
-            Path("plugins/AllowUnzippedPlugins/init.py"),
-            Path("plugins/plugin1/init.py"),
+            Path("plugins/__init__.py"),
+            Path("plugins/dummy_plugin/src/__init__.py"),
+            Path("plugins/plugin1/__init__.py"),
         ]
 
-    spec_mock = MagicMock()
-    spec_from_file_location_mock.return_value = spec_mock
+        spec_mock = MagicMock()
+        spec_from_file_location_mock.return_value = spec_mock
 
-    loaded_module_mock = MagicMock()
-    instance_mock = MagicMock()
-    loaded_module_mock.PluginClass.return_value = instance_mock
-    module_from_spec_mock.return_value = loaded_module_mock
+        # Mock load_module
+        class MockLoadedModule:
+            AutoGPTPluginTemplate = AutoGPTPluginTemplate
+            PluginClass = TestData
+            
+        loaded_module_mock = MockLoadedModule()
+        module_from_spec_mock.return_value = loaded_module_mock
 
-    plugin_instance = AutoGPTAllowUnzippedPlugins()
-    unzipped_plugins = plugin_instance.load_unzipped_plugins()
-    assert unzipped_plugins == [instance_mock]
-
-    rglob_mock.assert_called_once_with("__init__.py")
-    spec_from_file_location_mock.assert_called_once_with(
-        "plugin1", "plugins/plugin1/__init__.py"
-    )
-    module_from_spec_mock.assert_called_once_with(spec_mock)
-    spec_mock.loader.exec_module.assert_called_once_with(loaded_module_mock)
-    assert "plugin1" in sys.modules
-    loaded_module_mock.PluginClass.assert_called_once_with()
+        plugin_instance = AutoGPTAllowUnzippedPlugins()
+        unzipped_plugins = plugin_instance.load_unzipped_plugins()
+        assert len(unzipped_plugins) == 3
+        assert unzipped_plugins[0].__class__.__name__ == "TestData"
+        assert "plugin1" in sys.modules


### PR DESCRIPTION
### Background
AutoGPT requires zipped plugins for security reasons, which can be tedious during the development process.
his plugin helps developers work with unzipped plugins during the dev process.

### Changes
Added "unzipped_plugins" to the plugins folder.

### Documentation
Updated the README

### Test Plan
Test provided