### PR TITLE
changing in SMPT port

### DIFF
--- a/src/autogpt_plugins/email/README.md
+++ b/src/autogpt_plugins/email/README.md
@@ -48,7 +48,7 @@ Append the following configuration settings to the end of the file:
 EMAIL_ADDRESS=
 EMAIL_PASSWORD=
 EMAIL_SMTP_HOST=smtp.gmail.com
-EMAIL_SMTP_PORT=587
+EMAIL_SMTP_PORT=465
 EMAIL_IMAP_SERVER=imap.gmail.com
 
 #Optional Settings


### PR DESCRIPTION
When using GMail, the port needs to be set to 465, due to this app is not able to do 2 factor auth, and uses web app password