### PR TITLE
Fix Email-Plugin: workspace folder and complex imap search

### DIFF
--- a/src/autogpt_plugins/email/__init__.py
+++ b/src/autogpt_plugins/email/__init__.py
@@ -53,7 +53,7 @@ class AutoGPTEmailPlugin(AutoGPTPluginTemplate):
                     "to": "<to>",
                     "subject": "<subject>",
                     "body": "<body>",
-                    "attachment": "<path_to_file>",
+                    "filename": "<attachment filename>",
                 },
                 send_email_with_attachment,
             )

--- a/src/autogpt_plugins/email/email_plugin/test_email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/test_email_plugin.py
@@ -9,6 +9,7 @@ from email_plugin import (
     bothEmailAndPwdSet,
     adjust_imap_folder_for_gmail,
     enclose_with_quotes,
+    split_imap_search_command,
 )
 from unittest.mock import mock_open
 import unittest
@@ -125,6 +126,29 @@ class TestEmailPlugin(unittest.TestCase):
         assert enclose_with_quotes("whitespace\te") == '"whitespace\te"'
         assert enclose_with_quotes("\"mixed quotes'") == "\"mixed quotes'"
         assert enclose_with_quotes("'mixed quotes\"") == "'mixed quotes\""
+
+    def test_split_imap_search_command(self):
+        self.assertEqual(split_imap_search_command("SEARCH"), ["SEARCH"])
+        self.assertEqual(
+            split_imap_search_command("SEARCH UNSEEN"), ["SEARCH", "UNSEEN"]
+        )
+        self.assertEqual(
+            split_imap_search_command("  SEARCH   UNSEEN  "), ["SEARCH", "UNSEEN"]
+        )
+        self.assertEqual(
+            split_imap_search_command(
+                "FROM speixoto@caicm.ca SINCE 01-JAN-2022 BEFORE 01-FEB-2023 HAS attachment xls OR HAS attachment xlsx"
+            ),
+            [
+                "FROM",
+                "speixoto@caicm.ca SINCE 01-JAN-2022 BEFORE 01-FEB-2023 HAS attachment xls OR HAS attachment xlsx",
+            ],
+        )
+        self.assertEqual(
+            split_imap_search_command("BODY here is my long body"),
+            ["BODY", "here is my long body"],
+        )
+        self.assertEqual(split_imap_search_command(""), [])
 
     @patch("imaplib.IMAP4_SSL")
     @patch.dict(


### PR DESCRIPTION

This fixes complex imap search commands as mentioned in this issue:
https://github.com/Significant-Gravitas/Auto-GPT-Plugins/issues/47
e.g.:
'imap_search_command': 'FROM speixoto@caicm.ca SINCE 01-JAN-2022 BEFORE 01-FEB-2023 HAS attachment xls OR HAS attachment xlsx'

This PR changed how workspaces work in AutoGPT:
https://github.com/Significant-Gravitas/Auto-GPT/pull/2982

This PR fixes this.