### PR TITLE
docs: update docs to ensure plugins folder exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Follow these steps to configure the Auto-GPT Plugins:
 
    If you haven't already, follow the installation instructions provided by [Auto-GPT](https://github.com/Significant-Gravitas/Auto-GPT) to install it.
 
-1. **Run the following to pull the plugins folder down from the `root` of `autogpt`**
+1. **Run the following to pull the plugins folder down from the `root` of `Auto-GPT` directory**
 
     To download it directly from your Auto-GPT directory, you can run this command on Linux or MacOS:
 


### PR DESCRIPTION
This was confusing at first and caused me to install the `plugins` directory in the wrong place. There's a `autogpt` directory which can be confused as the `root`. I feel like this change clears things up