### PR TITLE
API Tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /src/autogpt_plugins/bing_search @ForestLinSen
 /src/autogpt_plugins/news_search @PalAditya
 /src/autogpt_plugins/wikipedia_search @pierluigi-failla
+/src/autogpt_plugins/api_tools @sidewaysthought

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ For interactionless use, set `ALLOWLISTED_PLUGINS=example-plugin1,example-plugin
 | Bing Search |  This search plugin integrates Bing search engines into Auto-GPT. | [autogpt_plugins/bing_search](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/bing_search)
 | News Search |  This search plugin integrates News Articles searches, using the NewsAPI aggregator into Auto-GPT. | [autogpt_plugins/news_search](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/news_search)
 | Wikipedia Search | This allows AutoGPT to use Wikipedia directly. | [autogpt_plugins/wikipedia_search](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/wikipedia_search)
+| API Tools | This allows AutoGPT to make API calls of various kinds. | [autogpt_plugins/api_tools](https://github.com/Significant-Gravitas/Auto-GPT-Plugins/tree/master/src/autogpt_plugins/api_tools)
 
 Some third-party plugins have been created by contributors that are not included in this repository. For more information about these plugins, please visit their respective GitHub pages.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ auto_gpt_plugin_template
 newsapi-python
 requests
 requests-mock
+validators
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,6 @@ tweepy==4.13.0
 pandas
 auto_gpt_plugin_template
 newsapi-python
+requests
+requests-mock
 pytest

--- a/src/autogpt_plugins/api_tools/README.md
+++ b/src/autogpt_plugins/api_tools/README.md
@@ -1,0 +1,14 @@
+# Wikipedia Search Plugin
+
+The Wikipedia Search plugin will allow AutoGPT to directly interact with Wikipedia.
+
+## Key Features:
+- Wikipedia Search performs search queries using Wikipedia.
+
+## Installation:
+1. Download the Wikipedia Search Plugin repository as a ZIP file.
+2. Copy the ZIP file into the "plugins" folder of your Auto-GPT project.
+
+## AutoGPT Configuration
+
+Set `ALLOWLISTED_PLUGINS=autogpt-wikipedia-search,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.

--- a/src/autogpt_plugins/api_tools/README.md
+++ b/src/autogpt_plugins/api_tools/README.md
@@ -1,14 +1,14 @@
-# Wikipedia Search Plugin
+# API Tools Plugin
 
-The Wikipedia Search plugin will allow AutoGPT to directly interact with Wikipedia.
+The API Tools Plugin enables Auto-GPT to communicate with APIs.
 
 ## Key Features:
-- Wikipedia Search performs search queries using Wikipedia.
+- Supports GET, POST, PUT, DELETE, PATCH, HEAD and OPTIONS
+- Tries to recover from strange values being used as parameters
+- Accepts custom header values
 
 ## Installation:
-1. Download the Wikipedia Search Plugin repository as a ZIP file.
-2. Copy the ZIP file into the "plugins" folder of your Auto-GPT project.
+As part of the AutoGPT plugins package, follow the [installation instructions](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) on the Auto-GPT-Plugins GitHub reporistory README page.
 
 ## AutoGPT Configuration
-
-Set `ALLOWLISTED_PLUGINS=autogpt-wikipedia-search,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.
+Set `ALLOWLISTED_PLUGINS=autogpt-api-tools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.

--- a/src/autogpt_plugins/api_tools/__init__.py
+++ b/src/autogpt_plugins/api_tools/__init__.py
@@ -1,0 +1,210 @@
+"""API Calls for Autogpt."""
+
+from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar
+from auto_gpt_plugin_template import AutoGPTPluginTemplate
+from .api_tools import _make_api_call
+
+PromptGenerator = TypeVar("PromptGenerator")
+
+class Message(TypedDict):
+    role: str
+    content: str
+
+class AutoGPTApiTools(AutoGPTPluginTemplate):
+    """
+    API Tools plugin for Autogpt.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._name = "autogpt-api-tools"
+        self._version = "0.1.0"
+        self._description = "Allow AutoGPT to make API calls to outside services."
+
+    def can_handle_on_response(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the on_response method.
+        Returns:
+            bool: True if the plugin can handle the on_response method."""
+        return False
+
+    def on_response(self, response: str, *args, **kwargs) -> str:
+        """This method is called when a response is received from the model."""
+        pass
+
+    def can_handle_post_prompt(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_prompt method.
+        Returns:
+            bool: True if the plugin can handle the post_prompt method."""
+        return True
+
+    def can_handle_on_planning(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the on_planning method.
+        Returns:
+            bool: True if the plugin can handle the on_planning method."""
+        return False
+
+    def on_planning(
+            self, prompt: PromptGenerator, messages: List[str]
+    ) -> Optional[str]:
+        """This method is called before the planning chat completeion is done.
+        Args:
+            prompt (PromptGenerator): The prompt generator.
+            messages (List[str]): The list of messages.
+        """
+        pass
+
+    def can_handle_post_planning(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_planning method.
+        Returns:
+            bool: True if the plugin can handle the post_planning method."""
+        return False
+
+    def post_planning(self, response: str) -> str:
+        """This method is called after the planning chat completeion is done.
+        Args:
+            response (str): The response.
+        Returns:
+            str: The resulting response.
+        """
+        pass
+
+    def can_handle_pre_instruction(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the pre_instruction method.
+        Returns:
+            bool: True if the plugin can handle the pre_instruction method."""
+        return False
+
+    def pre_instruction(self, messages: List[str]) -> List[str]:
+        """This method is called before the instruction chat is done.
+        Args:
+            messages (List[str]): The list of context messages.
+        Returns:
+            List[str]: The resulting list of messages.
+        """
+        pass
+
+    def can_handle_on_instruction(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the on_instruction method.
+        Returns:
+            bool: True if the plugin can handle the on_instruction method."""
+        return False
+
+    def on_instruction(self, messages: List[str]) -> Optional[str]:
+        """This method is called when the instruction chat is done.
+        Args:
+            messages (List[str]): The list of context messages.
+        Returns:
+            Optional[str]: The resulting message.
+        """
+        pass
+
+    def can_handle_post_instruction(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_instruction method.
+        Returns:
+            bool: True if the plugin can handle the post_instruction method."""
+        return False
+
+    def post_instruction(self, response: str) -> str:
+        """This method is called after the instruction chat is done.
+        Args:
+            response (str): The response.
+        Returns:
+            str: The resulting response.
+        """
+        pass
+
+    def can_handle_pre_command(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the pre_command method.
+        Returns:
+            bool: True if the plugin can handle the pre_command method."""
+        return False
+
+    def pre_command(
+            self, command_name: str, arguments: Dict[str, Any]
+    ) -> Tuple[str, Dict[str, Any]]:
+        """This method is called before the command is executed.
+        Args:
+            command_name (str): The command name.
+            arguments (Dict[str, Any]): The arguments.
+        Returns:
+            Tuple[str, Dict[str, Any]]: The command name and the arguments.
+        """
+        pass
+
+    def can_handle_post_command(self) -> bool:
+        """This method is called to check that the plugin can
+        handle the post_command method.
+        Returns:
+            bool: True if the plugin can handle the post_command method."""
+        return False
+
+    def post_command(self, command_name: str, response: str) -> str:
+        """This method is called after the command is executed.
+        Args:
+            command_name (str): The command name.
+            response (str): The response.
+        Returns:
+            str: The resulting response.
+        """
+        pass
+
+    def can_handle_chat_completion(
+            self,
+            messages: list[Dict[Any, Any]],
+            model: str,
+            temperature: float,
+            max_tokens: int,
+    ) -> bool:
+        """This method is called to check that the plugin can
+        handle the chat_completion method.
+        Args:
+            messages (Dict[Any, Any]): The messages.
+            model (str): The model name.
+            temperature (float): The temperature.
+            max_tokens (int): The max tokens.
+        Returns:
+            bool: True if the plugin can handle the chat_completion method."""
+        return False
+
+    def handle_chat_completion(
+            self,
+            messages: list[Dict[Any, Any]],
+            model: str,
+            temperature: float,
+            max_tokens: int,
+    ) -> str:
+        """This method is called when the chat completion is done.
+        Args:
+            messages (Dict[Any, Any]): The messages.
+            model (str): The model name.
+            temperature (float): The temperature.
+            max_tokens (int): The max tokens.
+        Returns:
+            str: The resulting response.
+        """
+        return None
+
+    def post_prompt(self, prompt: PromptGenerator) -> PromptGenerator:
+        """This method is called just after the generate_prompt is called,
+            but actually before the prompt is generated.
+        Args:
+            prompt (PromptGenerator): The prompt generator.
+        Returns:
+            PromptGenerator: The prompt generator.
+        """
+
+        prompt.add_command(
+            "make_api_call",
+            "Make an API call",
+            {"host": "<host>", "endpoint": "<endpoint>", "method": "<method>", "query_params": "<query_params>", "body": "<body>", "headers": "<headers>"},
+            _make_api_call
+        )
+        return prompt

--- a/src/autogpt_plugins/api_tools/__init__.py
+++ b/src/autogpt_plugins/api_tools/__init__.py
@@ -1,4 +1,4 @@
-"""API Calls for Autogpt."""
+"""API Tools for Autogpt."""
 
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, TypeVar
 from auto_gpt_plugin_template import AutoGPTPluginTemplate

--- a/src/autogpt_plugins/api_tools/api_tools.py
+++ b/src/autogpt_plugins/api_tools/api_tools.py
@@ -1,0 +1,156 @@
+"""API Call command for Autogpt."""
+
+import json
+import requests
+import re
+
+from typing import Optional, Dict
+from urllib.parse import urlparse
+from urllib.parse import urljoin
+
+def _make_api_call(
+        host: str = "https://localhost", 
+        endpoint: str = "/", 
+        method: str = "GET", 
+        query_params = {},
+        body: str = "", 
+        headers = {},
+        timeout_secs: int = 120) -> str:
+    """Return the results of an API call
+    Args:
+        host (str): The host of the API.
+        endpoint (str): The endpoint of the API.
+        method (str): The method of the API.
+        query_params (dict): The query parameters of the API.
+        body (str): The body of the API.
+        headers (dict): The headers of the API.
+        timeout_secs (int): The timeout in seconds.
+    Returns:
+        str: A JSON string containing the results of the API 
+            call in the format
+            {"response": "<response>", "status_code": <status_code>}
+    """
+
+    def is_valid_url(url: str) -> bool:
+
+        """Return True if the url is valid, False otherwise."""
+
+        try:
+            result = urlparse(url)
+            return all([result.scheme, result.netloc])
+        except ValueError:
+            return False
+        
+    # End of is_valid_url
+
+    def sanitize(input_string: str) -> str:
+
+        """Remove potentially harmful characters from the input string."""
+        
+        try:
+            data = json.loads(input_string)
+        except json.JSONDecodeError:
+            # If it's not JSON, sanitize it as a single value.
+            sanitized_string = re.sub(r'[^a-zA-Z0-9_: -{}[\],"]', '', input_string)
+        else:
+            # If it's JSON, sanitize all the values.
+            sanitized_string = json.dumps({sanitize(k): sanitize(str(v)) for k, v in data.items()})
+
+        return sanitized_string
+    
+    # End of sanitize
+
+    # Initialize variables  
+    response = {}
+    if isinstance(query_params, str):
+        try:
+            query_params = json.loads(query_params)
+        except json.JSONDecodeError:
+            query_params = {}
+    if isinstance(headers, str):
+        try:
+            headers = json.loads(headers)
+        except json.JSONDecodeError:
+            headers = {}
+
+    # Validate inputs
+    if not isinstance(query_params, dict):
+        raise ValueError("query_params must be a dictionary")
+    if not isinstance(headers, dict):
+        raise ValueError("headers must be a dictionary")
+    if not isinstance(timeout_secs, int) or timeout_secs <= 0:
+        raise ValueError("timeout_secs must be a positive integer")
+
+    # Prepare the request -- URL
+    if not host.startswith(("http://", "https://")):
+        host = f"https://{host}"
+    url = urljoin(host, endpoint)
+    if not is_valid_url(url):
+        return json.dumps({
+            "response": 'Invalid host or endpoint',
+            "status_code": None
+        })
+    
+    # Prepare the request -- Method
+    allowed_methods = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"]
+    if method not in allowed_methods:
+        raise ValueError("Invalid method: " + method)
+
+    # Prepare the request -- Headers
+    if 'Content-Type' not in headers:
+        headers['Content-Type'] = 'application/json'
+    sanitized_headers = {sanitize(k): sanitize(v) for k, v in headers.items()}
+    
+    # Prepare the request -- Body
+    sanitized_body = sanitize(str(body))
+    content_type = sanitized_headers.get('Content-Type')
+    if content_type == 'application/json':
+        try:
+            body_dict = json.loads(sanitized_body)
+        except json.JSONDecodeError:
+            body_dict = sanitized_body
+    elif content_type == 'application/x-www-form-urlencoded':
+        body_dict = sanitized_body
+    elif content_type == 'multipart/form-data':
+        raise ValueError("Content type 'multipart/form-data' is not supported.")
+    else:
+        raise ValueError('Unsupported Content-Type: ' + content_type)
+    
+    # Prepare the request -- Query Parameters
+    sanitized_query_params = {sanitize(k): sanitize(v) for k, v in query_params.items()}
+
+    # Make the request
+    try:
+        if method == "GET":
+            response = requests.get(url, params=sanitized_query_params, headers=sanitized_headers, timeout=timeout_secs)
+        elif method == "HEAD":
+            response = requests.head(url, params=sanitized_query_params, headers=sanitized_headers, timeout=timeout_secs)
+        elif method == "OPTIONS":
+            response = requests.options(url, params=sanitized_query_params, headers=sanitized_headers, timeout=timeout_secs)
+        elif method == "POST":
+            response = requests.post(url, params=sanitized_query_params, json=body_dict, headers=sanitized_headers, timeout=timeout_secs)
+        elif method == "PUT":
+            response = requests.put(url, params=sanitized_query_params, json=body_dict, headers=sanitized_headers, timeout=timeout_secs)
+        elif method == "DELETE":
+            response = requests.delete(url, params=sanitized_query_params, json=body_dict, headers=sanitized_headers, timeout=timeout_secs)
+        elif method == "PATCH":
+            response = requests.patch(url, params=sanitized_query_params, json=body_dict, headers=sanitized_headers, timeout=timeout_secs)
+        else:
+            raise ValueError("Invalid method: " + method)
+        
+        try:
+            response_text = json.loads(response.text)
+        except json.JSONDecodeError:
+            response_text = response.text
+        response = {
+            "response": response_text,
+            "status_code": response.status_code
+        }
+
+    except requests.exceptions.RequestException as e:
+        response = {
+            "error": str(e),
+            "status_code": None
+        }
+
+    return json.dumps(response)

--- a/src/autogpt_plugins/api_tools/test_api_tools.py
+++ b/src/autogpt_plugins/api_tools/test_api_tools.py
@@ -1,289 +1,575 @@
 import pytest
-import requests
+import random
 import requests_mock
 import json
 from .api_tools import _make_api_call
 
-def test_make_api_call_get_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.get(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+class TestAutoGPTAPITools():
 
-def test_make_api_call_post_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Post Response'
-        mock_req.post(mock_url, text=mock_response)
-        body = {"message": "test message"}
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body=body)
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    # Test call methods
 
-def test_make_api_call_put_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Put Response'
-        mock_req.put(mock_url, text=mock_response)
-        body = {"message": "test message"}
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='PUT', body=body)
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_get(self):
+        """Test the _make_api_call() function with a GET request."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_delete_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Delete Response'
-        mock_req.delete(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='DELETE')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_post(self):
+        """Test the _make_api_call() function with a POST request."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='POST')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_patch_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Patch Response'
-        mock_req.patch(mock_url, text=mock_response)
-        body = {"message": "test message"}
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='PATCH', body=body)
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_put(self):
+        """Test the _make_api_call() function with a PUT request."""
+        with requests_mock.Mocker() as m:
+            m.put('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='PUT')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_head_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Head Response'
-        mock_req.head(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='HEAD')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_delete(self):
+        """Test the _make_api_call() function with a DELETE request."""
+        with requests_mock.Mocker() as m:
+            m.delete('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='DELETE')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_option_method():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Option Response'
-        mock_req.options(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='OPTIONS')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_patch(self):
+        """Test the _make_api_call() function with a PATCH request."""
+        with requests_mock.Mocker() as m:
+            m.patch('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='PATCH')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_invalid_host():
-    response = _make_api_call(host='invalid_host', endpoint='/endpoint', method='GET')
-    response_dict = json.loads(response)
-    assert response_dict['response'] == 'Invalid host or endpoint'
-    assert response_dict['status_code'] is None
+    def test_api_call_head(self):
+        """Test the _make_api_call() function with a HEAD request."""
+        with requests_mock.Mocker() as m:
+            m.head('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='HEAD')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_invalid_endpoint():
-    with requests_mock.Mocker() as mock_req:
-        with pytest.raises(ValueError):
-            _make_api_call(host='https://mockapi.com', endpoint='endpoint', method='GET')
+    def test_api_call_options(self):
+        """Test the _make_api_call() function with a OPTIONS request."""
+        with requests_mock.Mocker() as m:
+            m.options('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='OPTIONS')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_invalid_url():
-    with requests_mock.Mocker() as mock_req:
-        with pytest.raises(ValueError):
-            _make_api_call(host='https://mockapi.com', endpoint='https://mockapi.com/endpoint', method='GET')
+    # Test host errors
 
-def test_make_api_call_invalid_method():
-    with requests_mock.Mocker() as mock_req:
-        with pytest.raises(ValueError):
-            _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='INVALID_METHOD')
+    def test_api_call_valid_host(self):
+        """Test the _make_api_call() function with a valid host."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_query_params_eq_string():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.get(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', query_params='test=1')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_valid_host_https(self):
+        """Test the _make_api_call() function with a valid host using HTTPS."""
+        with requests_mock.Mocker() as m:
+            m.get('https://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('https://example.com', '/endpoint')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_query_params_eq_dict():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.get(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', query_params={'test': 1})
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_without_protocol(self):
+        """Test the _make_api_call() function with a host without a protocol."""
+        with requests_mock.Mocker() as m:
+            m.get('https://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('example.com', '/endpoint')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_body_eq_json():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body='{"message": "test message"}')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_garbage(self):
+        """Test the _make_api_call() function with a garbage host."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('garbage', '/endpoint')
+        assert "Invalid URL" in str(excinfo.value)
 
-def test_make_api_call_body_eq_dict():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body={"message": "test message"})
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_empty(self):
+        """Test the _make_api_call() function with an empty host."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('', '/endpoint')
+        assert "Invalid URL" in str(excinfo.value)
 
-def test_make_api_call_body_eq_list():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body=["test message"])
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_number(self):
+        """Test the _make_api_call() function with a host that is a number."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call(123, '/endpoint')
+        assert "host must be a string" in str(excinfo.value)
 
-def test_make_api_call_body_eq_string():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body="test message")
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_none(self):
+        """Test the _make_api_call() function with no host."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call(None, '/endpoint')
+        assert "host must be a string" in str(excinfo.value)
 
-def test_make_api_call_body_eq_none():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body=None)
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_invalid_protocol(self):
+        """Test the _make_api_call() function with an invalid protocol."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('ftp://example.com', '/endpoint')
+        assert "Invalid URL" in str(excinfo.value)
 
-def test_make_api_call_headers_eq_json():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers='{"Content-Type": "application/json"}')
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_query_marker(self):
+        """Test the _make_api_call() function with dangerous characters."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com?test=1', '/endpoint')
+        assert "Invalid URL" in str(excinfo.value)
 
-def test_make_api_call_headers_eq_string():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers="Content-Type: application/json")
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_host_query_param_marker(self):
+        """Test the _make_api_call() function with dangerous characters."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com?test=1', '/endpoint')
+        assert "Invalid URL" in str(excinfo.value)
 
-def test_make_api_call_headers_eq_dict():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers={"Content-Type": "application/json"})
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    # Test endpoint errors
 
-def test_make_api_call_headers_eq_none():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_response = 'Mock Response'
-        mock_req.post(mock_url, text=mock_response)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers=None)
-        expected_response = json.dumps({
-            "response": mock_response,
-            "status_code": 200
-        })
-        assert response == expected_response
+    def test_api_call_valid_endpoint(self):
+        """Test the _make_api_call() function with a valid endpoint."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_timeout_eq_int():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout=1)
-        expected_response = json.dumps({
-            "response": "Request timed out.",
-            "status_code": 408
-        })
-        assert response == expected_response
+    def test_api_call_valid_endpoint_with_query(self):
+        """Test the _make_api_call() function with a valid endpoint."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint?test=1', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint?test=1')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_timeout_eq_float():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout=1.0)
-        expected_response = json.dumps({
-            "response": "Request timed out.",
-            "status_code": 408
-        })
-        assert response == expected_response
+    def test_api_call_endpoint_empty(self):
+        """Test the _make_api_call() function with an empty endpoint."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
 
-def test_make_api_call_timeout_eq_string():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout="1.0")
-        expected_response = json.dumps({
-            "response": "Request timed out.",
-            "status_code": 408
-        })
-        assert response == expected_response
+    def test_api_call_endpoint_number(self):
+        """Test the _make_api_call() function with an endpoint that is a number."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', 123)
+        assert "endpoint must be a string" in str(excinfo.value)
 
-def test_make_api_call_timeout_eq_none():
-    with requests_mock.Mocker() as mock_req:
-        mock_url = 'https://mockapi.com/endpoint'
-        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
-        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout=None)
-        expected_response = json.dumps({
-            "response": "Request timed out.",
-            "status_code": 408
-        })
-        assert response == expected_response
+    def test_api_call_endpoint_none(self):
+        """Test the _make_api_call() function with no endpoint."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', None)
+        assert "endpoint must be a string" in str(excinfo.value)
+
+    # Test method errors    
+
+    def test_api_call_invalid_method(self):
+        """Test the _make_api_call() function with an invalid method."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', method='INVALID')
+        assert "Invalid method: INVALID" in str(excinfo.value)          
+
+    def test_api_call_none_method(self):
+        """Test the _make_api_call() function with no method."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', method=None)
+        assert "method must be a string" in str(excinfo.value)
+
+    def test_api_call_empty_method(self):
+        """Test the _make_api_call() function with an empty method."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', method='')
+        assert "Invalid method" in str(excinfo.value)
+
+    def test_api_call_number_method(self):
+        """Test the _make_api_call() function with a number as a method."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', method=123)
+        assert "method must be a string" in str(excinfo.value)
+
+    def test_api_call_lowercase_method(self):
+        """Test the _make_api_call() function with a lowercase method."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='get')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    # Test query_params errors
+
+    def test_api_call_valid_query_params_with_number_as_dict_value(self):
+        """Test the _make_api_call() function with valid query_params."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', query_params={'test': 1})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_query_params_array(self):
+        """Test the _make_api_call() function with query_params that is an array."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', query_params=['test'])
+        assert "query_params must be a dictionary" in str(excinfo.value)
+
+    def test_api_call_query_params_string(self):
+        """Test the _make_api_call() function with query_params that is a string."""
+        # This is interpreted as JSON and converted to a dictionary
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', query_params='{"test": 1}')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_query_params_invalid_json_string(self):
+        """Test the _make_api_call() function with query_params that is an invalid JSON string."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', query_params='{test": 1')
+        assert "query_params must be a dictionary" in str(excinfo.value)
+
+    def test_api_call_query_params_number(self):
+        """Test the _make_api_call() function with query_params that is a number."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', query_params=123)
+        assert "query_params must be a dictionary" in str(excinfo.value)
+
+    def test_api_call_query_params_empty_string(self):
+        """Test the _make_api_call() function with query_params that is an empty string."""
+        # This should be converted to an empty dictionary
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', query_params='')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_query_params_none(self):
+        """Test the _make_api_call() function with no query_params."""
+        # This should be converted to an empty dictionary
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', query_params=None)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_query_params_empty_dict(self):
+        """Test the _make_api_call() function with an empty query_params."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', query_params={})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_query_params_number(self):
+        """Test the _make_api_call() function with query_params that is a number."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', query_params=123)
+        assert "query_params must be a dictionary" in str(excinfo.value)
+
+    def test_api_call_query_params_dict_has_key_none_value(self):
+        """Test the _make_api_call() function with query_params that has a None value."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', query_params={'test': None})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_query_params_dict_malformed(self):
+        """Test the _make_api_call() function with query_params that is a malformed dictionary."""
+        with pytest.raises(ValueError) as excinfo:
+            _make_api_call('http://example.com', '/endpoint', query_params={None: 'test'})
+        assert "query_params cannot contain None keys" in str(excinfo.value)
+
+    # Test body errors
+
+    def test_api_call_valid_body_with_24k_text(self):
+        """Test the _make_api_call() function with valid body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method='POST', body='a' * 24000)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_calll_valid_body_with_random_text(self):
+        """Test the _make_api_call() function with valid body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='a' * random.randint(1, 24000))
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_valid_body_with_control_code_text(self):
+        """Test the _make_api_call() function with valid body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='\x00')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_valid_body_with_unicode_text(self):
+        """Test the _make_api_call() function with valid body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body=u'\u2713')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_valid_body_with_utf8_text(self):
+        """Test the _make_api_call() function with valid body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body=u'\u2713'.encode('utf-8'))
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_valid_body_with_utf16_text(self):
+        """Test the _make_api_call() function with valid body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", 
+                                    body=u'\u2713'.encode('utf-16'))
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_body_empty(self):
+        """Test the _make_api_call() function with an empty body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_body_none(self):
+        """Test the _make_api_call() function with a None body."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_body_not_string(self):
+        """Test the _make_api_call() function with a body that is not a string."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body=1)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_body_json(self):
+        """Test the _make_api_call() function with a body that is json."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body=json.dumps({'test': 'test'}))
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_body_json_invalid(self):
+        """Test the _make_api_call() function with a body that is invalid json."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='{"test": "test"]')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_body_xml(self):
+        """Test the _make_api_call() function with a body that is xml."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='<test>test</test>')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_body_xml_invalid(self):
+        """Test the _make_api_call() function with a body that is invalid xml."""
+        with requests_mock.Mocker() as m:
+            m.post('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', method="POST", body='<test>test</test>')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    # Test headers errors
+
+    def test_api_call_valid_headers(self):
+        """Test the _make_api_call() function with valid headers."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', headers={'test': 'test'})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_valid_headers_with_random_text(self):
+        """Test the _make_api_call() function with valid headers."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', headers={'test': 'a' * random.randint(1, 24000)})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_valid_headers_with_control_code_text(self):
+        """Test the _make_api_call() function with valid headers."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', headers={'test': '\x00'})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_valid_headers_with_unicode_text(self):
+        """Test the _make_api_call() function with valid headers."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', headers={'test': u'\u2713'})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_headers_with_array(self):
+        """Test the _make_api_call() function with headers that are an array."""
+        # This is not a valid header, and ValueError "headers must be a dictionary" will be thrown
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', headers=['test'])
+        assert "headers must be a dictionary" in str(e.value)
+
+    def test_api_call_headers_with_empty_dict(self):
+        """Test the _make_api_call() function with headers that are an empty dict."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', headers={})
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_headers_with_none(self):
+        """Test the _make_api_call() function with headers that are None."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', headers=None)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_headers_with_not_dict(self):
+        """Test the _make_api_call() function with headers that are not a dict."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', headers=1)
+        assert "headers must be a dictionary" in str(e.value)
+
+    def test_api_call_headers_with_invalid_key(self):
+        """Test the _make_api_call() function with headers that have an invalid key."""
+        headers = {'test': 'test'}
+        headers[1] = 'test'
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200, request_headers={'test': 'test', '1': 'test'})
+            result = _make_api_call('http://example.com', '/endpoint', headers=headers)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    def test_api_call_headers_with_invalid_value(self):
+        """Test the _make_api_call() function with headers that have an invalid value."""
+        headers = {'test': 'test'}
+        headers['test'] = 1
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200, request_headers={'test': '1'})
+            result = _make_api_call('http://example.com', '/endpoint', headers=headers)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+            assert json.loads(result)['response'] == 'success'
+
+    # Test timeout_secs errors
+
+    def test_api_call_valid_timeout_secs(self):
+        """Test the _make_api_call() function with valid timeout_secs."""
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', timeout_secs=1)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_timeout_secs_with_string(self):
+        """Test the _make_api_call() function with timeout_secs that is a string."""
+        # The string will be converted to an integer, so no error will be thrown
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', timeout_secs='1')
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_timeout_secs_with_float(self):
+        """Test the _make_api_call() function with timeout_secs that is a float."""
+        # The float will be converted to an integer, so no error will be thrown
+        with requests_mock.Mocker() as m:
+            m.get('http://example.com/endpoint', text='success', status_code=200)
+            result = _make_api_call('http://example.com', '/endpoint', timeout_secs=1.0)
+            assert json.loads(result)['status'] == 'success'
+            assert json.loads(result)['status_code'] == 200
+
+    def test_api_call_timeout_secs_with_negative_number(self):
+        """Test the _make_api_call() function with timeout_secs that is a negative number."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', timeout_secs=-1)
+        assert "timeout_secs must be a positive integer" in str(e.value)
+
+    def test_api_call_timeout_secs_with_zero(self):
+        """Test the _make_api_call() function with timeout_secs that is zero."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', timeout_secs=0)
+        assert "timeout_secs must be a positive integer" in str(e.value)
+
+    def test_api_call_timeout_secs_with_empty_string(self):
+        """Test the _make_api_call() function with timeout_secs that is an empty string."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', timeout_secs='')
+        assert "timeout_secs must be an integer" in str(e.value)
+
+    def test_api_call_timeout_secs_with_none_value(self):
+        """Test the _make_api_call() function with timeout_secs that is None."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', timeout_secs=None)
+        assert "timeout_secs must be an integer" in str(e.value)
+
+    def test_api_call_timeout_secs_with_random_text(self):
+        """Test the _make_api_call() function with timeout_secs that is random text."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', timeout_secs='test')
+        assert "timeout_secs must be an integer" in str(e.value)
+
+    def test_api_call_timeout_secs_with_control_code_text(self):
+        """Test the _make_api_call() function with timeout_secs that is a control code."""
+        with pytest.raises(ValueError) as e:
+            _make_api_call('http://example.com', '/endpoint', timeout_secs='\x00')
+        assert "timeout_secs must be an integer" in str(e.value)

--- a/src/autogpt_plugins/api_tools/test_api_tools.py
+++ b/src/autogpt_plugins/api_tools/test_api_tools.py
@@ -1,0 +1,289 @@
+import pytest
+import requests
+import requests_mock
+import json
+from .api_tools import _make_api_call
+
+def test_make_api_call_get_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.get(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_post_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Post Response'
+        mock_req.post(mock_url, text=mock_response)
+        body = {"message": "test message"}
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body=body)
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_put_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Put Response'
+        mock_req.put(mock_url, text=mock_response)
+        body = {"message": "test message"}
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='PUT', body=body)
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_delete_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Delete Response'
+        mock_req.delete(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='DELETE')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_patch_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Patch Response'
+        mock_req.patch(mock_url, text=mock_response)
+        body = {"message": "test message"}
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='PATCH', body=body)
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_head_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Head Response'
+        mock_req.head(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='HEAD')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_option_method():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Option Response'
+        mock_req.options(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='OPTIONS')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_invalid_host():
+    response = _make_api_call(host='invalid_host', endpoint='/endpoint', method='GET')
+    response_dict = json.loads(response)
+    assert response_dict['response'] == 'Invalid host or endpoint'
+    assert response_dict['status_code'] is None
+
+def test_make_api_call_invalid_endpoint():
+    with requests_mock.Mocker() as mock_req:
+        with pytest.raises(ValueError):
+            _make_api_call(host='https://mockapi.com', endpoint='endpoint', method='GET')
+
+def test_make_api_call_invalid_url():
+    with requests_mock.Mocker() as mock_req:
+        with pytest.raises(ValueError):
+            _make_api_call(host='https://mockapi.com', endpoint='https://mockapi.com/endpoint', method='GET')
+
+def test_make_api_call_invalid_method():
+    with requests_mock.Mocker() as mock_req:
+        with pytest.raises(ValueError):
+            _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='INVALID_METHOD')
+
+def test_make_api_call_query_params_eq_string():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.get(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', query_params='test=1')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_query_params_eq_dict():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.get(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', query_params={'test': 1})
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_body_eq_json():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body='{"message": "test message"}')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_body_eq_dict():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body={"message": "test message"})
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_body_eq_list():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body=["test message"])
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_body_eq_string():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body="test message")
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_body_eq_none():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', body=None)
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_headers_eq_json():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers='{"Content-Type": "application/json"}')
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_headers_eq_string():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers="Content-Type: application/json")
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_headers_eq_dict():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers={"Content-Type": "application/json"})
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_headers_eq_none():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_response = 'Mock Response'
+        mock_req.post(mock_url, text=mock_response)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='POST', headers=None)
+        expected_response = json.dumps({
+            "response": mock_response,
+            "status_code": 200
+        })
+        assert response == expected_response
+
+def test_make_api_call_timeout_eq_int():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout=1)
+        expected_response = json.dumps({
+            "response": "Request timed out.",
+            "status_code": 408
+        })
+        assert response == expected_response
+
+def test_make_api_call_timeout_eq_float():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout=1.0)
+        expected_response = json.dumps({
+            "response": "Request timed out.",
+            "status_code": 408
+        })
+        assert response == expected_response
+
+def test_make_api_call_timeout_eq_string():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout="1.0")
+        expected_response = json.dumps({
+            "response": "Request timed out.",
+            "status_code": 408
+        })
+        assert response == expected_response
+
+def test_make_api_call_timeout_eq_none():
+    with requests_mock.Mocker() as mock_req:
+        mock_url = 'https://mockapi.com/endpoint'
+        mock_req.get(mock_url, exc=requests.exceptions.ConnectTimeout)
+        response = _make_api_call(host='https://mockapi.com', endpoint='/endpoint', method='GET', timeout=None)
+        expected_response = json.dumps({
+            "response": "Request timed out.",
+            "status_code": 408
+        })
+        assert response == expected_response


### PR DESCRIPTION
Adding a plugin for consideration that (hopefully) supports the various API call methods so ChatGPT can reach out to the internet. I am expecting the toolset to expand as people ask or contribute new functionality. For example, at some point, someone will want to authenticate using bearer tokens, base64-encoded credentials, or *cringes* OAuth2. At that time, authentication commands will need to be added to facilitate, as well as secure storage *outside* of the ChatGPT interface, etc., etc.

Until then, gets and posts to known simple sources are good.