### PR TITLE
AutoGPT Discord Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Some third-party plugins have been created by contributors that are not included
 | Crypto | Trade crypto with Auto-GPT | [isaiahbjork/Auto-GPT-Crypto-Plugin](https://github.com/isaiahbjork/Auto-GPT-Crypto-Plugin)
 | iMessage | Send and Get iMessages using Auto-GPT | [danikhan632/Auto-GPT-Messages-Plugin](https://github.com/danikhan632/Auto-GPT-Messages-Plugin)
 | Alpaca-Trading | Trade stocks and crypto, paper or live with Auto-GPT | [danikhan632/Auto-GPT-AlpacaTrader-Plugin](https://github.com/danikhan632/Auto-GPT-AlpacaTrader-Plugin)
+| Discord | Interact with your Auto-GPT instance through Discord | [gravelBridge/AutoGPT-Discord](https://github.com/gravelBridge/AutoGPT-Discord)
 
 ## Configuration
 


### PR DESCRIPTION
A plugin to enable you to control your AutoGPT instance from Discord. Run AutoGPT, and control it from anywhere with Discord.

With this plugin, watch and interact with your AutoGPT instance from the comfort of Discord. You can literally be thousands of miles away, on your phone, and still monitor AutoGPT. In my opinion, that's pretty cool.