### PR TITLE
Fix encoding issues when reading emails using the email plugin

### DIFF
--- a/src/autogpt_plugins/email/email_plugin/email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin.py
@@ -158,7 +158,7 @@ def read_emails(imap_folder: str = "inbox", imap_search_command: str = "UNSEEN")
                 if isinstance(subject, bytes):
                     try:
                         # If the subject has unknown encoding, return blank
-                        f encoding is not None:
+                        if encoding is not None:
                             subject = subject.decode(encoding)
                         else:
                             subject = ""


### PR DESCRIPTION
**Fix encoding issues when reading emails in the email plugin**
- Identify encoding problems in email subject and body text
- Handle encoding issues elegantly if they are found
- Added comments to highlight functionality added

The previous version of the email plugin was encountering encoding errors when reading emails, as documented in the following issues (https://github.com/Significant-Gravitas/Auto-GPT-Plugins/issues/104, https://github.com/Significant-Gravitas/Auto-GPT-Plugins/issues/110). This PR attempts to resolve as many of the encoding issues as I was able to identify.