### PR TITLE
Add plugin to help streamline project management

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Some third-party plugins have been created by contributors that are not included
 | WolframAlpha | Access to WolframAlpha to do math and get accurate information | [gravelBridge/AutoGPT-WolframAlpha](https://github.com/gravelBridge/AutoGPT-WolframAlpha)
 | YouTube   | Various YouTube features including downloading and understanding | [jpetzke/AutoGPT-YouTube](https://github.com/jpetzke/AutoGPT-YouTube) |
 | Zapier webhooks | This plugin allows you to easily integrate Zapier connectivity | [AntonioCiolino/AutoGPT-Zapier](https://github.com/AntonioCiolino/AutoGPT-Zapier)
+| Project Management | Streamline your Project Management with ease: Jira, Trello, and Google Calendar Made Effortless| [minfenglu/AutoGPT-PM-Plugin](https://github.com/minfenglu/AutoGPT-PM-Plugin)
 
 ## Configuration
 


### PR DESCRIPTION
Add a third-party plugin to help project management. Currently, Trello is supported. Jira and Google Calendar plugins are under development. 