### PR TITLE
Reduce "command returned too much output" errors in email plugin

### DIFF
--- a/src/autogpt_plugins/email/__init__.py
+++ b/src/autogpt_plugins/email/__init__.py
@@ -20,8 +20,8 @@ class AutoGPTEmailPlugin(AutoGPTPluginTemplate):
     def __init__(self):
         super().__init__()
         self._name = "Auto-GPT-Email-Plugin"
-        self._version = "0.1.3"
-        self._description = "Auto-GPT Email Plugin: Supercharge email management."
+        self._version = "0.2.0"
+        self._description = "This plugin reads and send emails."
 
     def post_prompt(self, prompt: PromptGenerator) -> PromptGenerator:
         from .email_plugin.email_plugin import (
@@ -38,6 +38,8 @@ class AutoGPTEmailPlugin(AutoGPTPluginTemplate):
                 {
                     "imap_folder": "<imap_folder>",
                     "imap_search_command": "<imap_search_criteria_command>",
+                    "limit": "<email_count_return_limit>",
+                    "page": "<number_of_email_results_page>",
                 },
                 read_emails,
             )

--- a/src/autogpt_plugins/email/email_plugin/email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin.py
@@ -197,7 +197,11 @@ def read_emails(
             f"when searching with imap command `{imap_search_command}`"
         )
 
-    # Calculate paginated indexes
+    # Confirm that integer parameters are the right type
+    limit = int(limit)
+    page = int(page)
+
+    # Validate parameter values
     if limit < 1:
         raise ValueError("Error: The message limit should be 1 or greater")
 
@@ -206,6 +210,7 @@ def read_emails(
     if page < 1 or page > page_count:
         raise ValueError("Error: The page value references a page that is not part of the results")
 
+    # Calculate paginated indexes
     start_index = len(messages) - (page * limit + 1)
     end_index = start_index + limit
     start_index = max(start_index, 0)

--- a/src/autogpt_plugins/email/email_plugin/email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin.py
@@ -104,15 +104,19 @@ def send_email_with_attachment_internal(
         return f"Email went to {draft_folder}!"
 
 
-def read_emails(imap_folder: str = "inbox", imap_search_command: str = "UNSEEN") -> str:
+def read_emails(
+        imap_folder: str = "inbox", imap_search_command: str = "UNSEEN", limit: int = 5,
+        page: int = 1) -> str:
     """Read emails from an IMAP mailbox.
 
-    This function reads emails from a specified IMAP folder, using a given IMAP search command.
+    This function reads emails from a specified IMAP folder, using a given IMAP search command, limits, and page numbers.
     It returns a list of emails with their details, including the sender, recipient, date, CC, subject, and message body.
 
     Args:
         imap_folder (str, optional): The name of the IMAP folder to read emails from. Defaults to "inbox".
         imap_search_command (str, optional): The IMAP search command to filter emails. Defaults to "UNSEEN".
+        limit (int, optional): Number of email's the function should return. Defaults to 5 emails.
+        page (int, optional): The index of the page result the function should resturn. Defaults to 0, the first page.
 
     Returns:
         str: A list of dictionaries containing email details if there are any matching emails. Otherwise, returns
@@ -192,7 +196,22 @@ def read_emails(imap_folder: str = "inbox", imap_search_command: str = "UNSEEN")
             f"There are no Emails in your folder `{imap_folder}` "
             f"when searching with imap command `{imap_search_command}`"
         )
-    return messages
+
+    # Calculate paginated indexes
+    if limit < 1:
+        raise ValueError("Error: The message limit should be 1 or greater")
+
+    page_count = len(messages) // limit + (len(messages) % limit > 0)
+
+    if page < 1 or page > page_count:
+        raise ValueError("Error: The page value references a page that is not part of the results")
+
+    start_index = len(messages) - (page * limit + 1)
+    end_index = start_index + limit
+    start_index = max(start_index, 0)
+
+    # Return paginated indexes
+    return messages[start_index:end_index]
 
 
 def adjust_imap_folder_for_gmail(imap_folder: str, email_sender: str) -> str:

--- a/src/autogpt_plugins/email/email_plugin/email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin.py
@@ -8,6 +8,7 @@ import smtplib
 import time
 from email.header import decode_header
 from email.message import EmailMessage
+from bs4 import BeautifulSoup
 
 
 
@@ -166,6 +167,9 @@ def read_emails(imap_folder: str = "inbox", imap_search_command: str = "UNSEEN")
                         pass
 
                 body = get_email_body(msg)
+                # Clean email body
+                body = clean_email_body(body)
+
                 from_address = msg["From"]
                 to_address = msg["To"]
                 date = msg["Date"]
@@ -248,3 +252,35 @@ def split_imap_search_command(input_string):
     parts = [part.strip() for part in parts]
 
     return parts
+
+def clean_email_body(email_body):
+    """Remove formating and URL's from an email's body
+
+    Args:
+        email_body (str, optional): The email's body
+
+    Returns:
+        str: The email's body without any formating or URL's
+    """
+
+    # If body is None, return an empty string
+    if email_body is None: email_body = ""
+
+    # Remove any HTML tags
+    email_body = BeautifulSoup(email_body, "html.parser")
+    email_body = email_body.get_text()
+
+    # Remove return characters
+    email_body = "".join(email_body.splitlines())
+
+    # Remove extra spaces
+    email_body = " ".join(email_body.split())
+
+    # Remove unicode characters
+    email_body = email_body.encode("ascii", "ignore")
+    email_body = email_body.decode("utf-8", "ignore")
+
+    # Remove any remaining URL's
+    email_body = re.sub(r"http\S+", "", email_body)
+
+    return email_body

--- a/src/autogpt_plugins/email/email_plugin/email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin.py
@@ -216,7 +216,10 @@ def read_emails(
     start_index = max(start_index, 0)
 
     # Return paginated indexes
-    return messages[start_index:end_index]
+    if start_index == end_index:
+        return [messages[start_index]]
+    else:
+        return messages[start_index:end_index]
 
 
 def adjust_imap_folder_for_gmail(imap_folder: str, email_sender: str) -> str:

--- a/src/autogpt_plugins/email/email_plugin/email_plugin_debug.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin_debug.py
@@ -1,0 +1,7 @@
+from email_plugin import read_emails
+
+# emails = read_emails("inbox", "SINCE 17-May-2023")
+# emails = read_emails()
+emails = read_emails("inbox", "SINCE 15-May-2023", 10, 6)
+
+print("Done!")

--- a/src/autogpt_plugins/email/email_plugin/email_plugin_debug.py
+++ b/src/autogpt_plugins/email/email_plugin/email_plugin_debug.py
@@ -1,7 +1,0 @@
-from email_plugin import read_emails
-
-# emails = read_emails("inbox", "SINCE 17-May-2023")
-# emails = read_emails()
-emails = read_emails("inbox", "SINCE 15-May-2023", 10, 6)
-
-print("Done!")

--- a/src/autogpt_plugins/email/email_plugin/test_email_plugin.py
+++ b/src/autogpt_plugins/email/email_plugin/test_email_plugin.py
@@ -208,7 +208,7 @@ class TestEmailPlugin(unittest.TestCase):
         context.send_message.assert_called_once()
         context.quit.assert_called_once()
 
-    # Test for reading emails in a specific folder with a specific search command
+    # Test for reading emails in a specific folder with a specific search command and pagination
     @patch("imaplib.IMAP4_SSL")
     @patch.dict(
         os.environ,
@@ -234,7 +234,7 @@ class TestEmailPlugin(unittest.TestCase):
         mock_imap.return_value.fetch.return_value = (None, [(b"1", message.as_bytes())])
 
         # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected_result = [
             {
                 "From": MOCK_FROM,
@@ -271,7 +271,7 @@ class TestEmailPlugin(unittest.TestCase):
         mock_imap.return_value.fetch.return_value = (None, [])
 
         # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected = "There are no Emails in your folder `inbox` "
         expected += "when searching with imap command `UNSEEN`"
         assert result == expected
@@ -310,7 +310,7 @@ class TestEmailPlugin(unittest.TestCase):
         mock_imap.return_value.fetch.return_value = (None, [(b"1", message.as_bytes())])
 
         # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected_result = [
             {
                 "From": MOCK_FROM,
@@ -357,7 +357,7 @@ class TestEmailPlugin(unittest.TestCase):
         mock_imap.return_value.fetch.return_value = (None, [(b"1", message.as_bytes())])
 
         # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected_result = [
             {
                 "From": MOCK_FROM,
@@ -452,7 +452,7 @@ class TestEmailPlugin(unittest.TestCase):
         mock_imap.return_value.fetch.return_value = (None, [(b"1", message.as_bytes())])
 
         # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected_result = [
             {
                 "From": MOCK_FROM,
@@ -490,14 +490,14 @@ class TestEmailPlugin(unittest.TestCase):
         message["To"] = MOCK_TO
         message["Date"] = MOCK_DATE
         message["Subject"] = MOCK_SUBJECT
-        message.set_content("�������")
+        message.set_content("�������\n")
 
         # Set up mock IMAP server behavior
         mock_imap.return_value.search.return_value = (None, [b"1"])
         mock_imap.return_value.fetch.return_value = (None, [(b"1", message.as_bytes())])
 
         # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected_result = [
             {
                 "From": MOCK_FROM,
@@ -505,7 +505,7 @@ class TestEmailPlugin(unittest.TestCase):
                 "Date": MOCK_DATE,
                 "CC": "",
                 "Subject": MOCK_SUBJECT,
-                "Message Body": "�������\n",
+                "Message Body": "",
             }
         ]
         assert result == expected_result
@@ -541,8 +541,8 @@ class TestEmailPlugin(unittest.TestCase):
         mock_imap.return_value.search.return_value = (None, [b"1"])
         mock_imap.return_value.fetch.return_value = (None, [(b"1", message.as_bytes())])
 
-        # Test read_emails function
-        result = read_emails("inbox", "UNSEEN")
+        # Test read_emails with paginationfunction
+        result = read_emails("inbox", "UNSEEN", 1, 1)
         expected_result = [
             {
                 "From": MOCK_FROM,
@@ -550,7 +550,7 @@ class TestEmailPlugin(unittest.TestCase):
                 "Date": MOCK_DATE,
                 "CC": "",
                 "Subject": MOCK_SUBJECT,
-                "Message Body": MOCK_CONTENT,
+                "Message Body": "Email Title This is an email template with a return character and a link at the end (",
             }
         ]
         assert result == expected_result


### PR DESCRIPTION
**Motivation:**
As currently architected, the email plugin returns all of the email results for any query, and each email includes the full text of the email's body. Due to the input limitations of OpenAI, it is common for the email plugin to hit "command returned too much output" errors. Because the IMAP standard doesn't have options for reducing input length, AutoGPT lacks tools to resolve these errors.

**Changes:**
In response to these errors, this PR makes two main changes to reduce the amount of information that the email plugin returns at one time. First, the PR adds pagination to the read_emails function using limt and page parameters. Second, the PR adds a clean_email_body function, which removes formatting and URL's from an email's body in order to reduce the body's size.

**Testing:**
Added test to validate email body cleaning functionality and pagination.

**Future Work**
Even with the email body cleaning functionality, OpenAI can usually process less than a handful of emails at a time. In the future I will consider using the OpenAI API to summarize the email body in results for initial processing. Any feedback on whether using the OpenAI API inside a plugin is accepted or not would be helpful.