### PR TITLE
Further reduce "command returned too much output" errors in email plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ build
 colorama
 flake8
 isort
+openai
 newsapi-python
 pandas
 pylint

--- a/src/autogpt_plugins/email/__init__.py
+++ b/src/autogpt_plugins/email/__init__.py
@@ -33,7 +33,18 @@ class AutoGPTEmailPlugin(AutoGPTPluginTemplate):
 
         if bothEmailAndPwdSet():
             prompt.add_command(
-                "Read Emails",
+                "Read Emails and Return Summarized Results",
+                "read_summarized_emails",
+                {
+                    "imap_folder": "<imap_folder>",
+                    "imap_search_command": "<imap_search_criteria_command>",
+                    "limit": "<email_count_return_limit>",
+                    "page": "<number_of_email_results_page>",
+                },
+                read_emails,
+            )
+            prompt.add_command(
+                "Read Emails and Return Detailed Results",
                 "read_emails",
                 {
                     "imap_folder": "<imap_folder>",
@@ -50,7 +61,7 @@ class AutoGPTEmailPlugin(AutoGPTPluginTemplate):
                 send_email,
             )
             prompt.add_command(
-                "Send Email",
+                "Send Email with Attachments",
                 "send_email_with_attachment",
                 {
                     "to": "<to>",


### PR DESCRIPTION
**Motivation:**
Even with the changes in PR https://github.com/Significant-Gravitas/Auto-GPT-Plugins/pull/171, it is hard for AutoGTP to process more than a handful of emails at a time, making querying emails less valuable. A potential solution would be to generate an analog of a Google search, and return summarized emails first, and then return the full email.

**Changes:**
Added a read_summarized_emails functions in addition to the existing read_emails functions to return shorter emails, and facilitate querying a large volume of emails at a time. The summarizing is done using the ChatGPT API.

**Testing:**
Added test to validate email body cleaning functionality and pagination.

**Future Work**
AutoGPT doesn't usually start querying emails with read_summarized_emails, so I will need to find ways to give AutoGPT hints that it should start with that function, and then use read_emails for the full email.