### PR TITLE
fix: Fixed API tools plugin name

### DIFF
--- a/src/autogpt_plugins/api_tools/README.md
+++ b/src/autogpt_plugins/api_tools/README.md
@@ -11,4 +11,4 @@ The API Tools Plugin enables Auto-GPT to communicate with APIs.
 As part of the AutoGPT plugins package, follow the [installation instructions](https://github.com/Significant-Gravitas/Auto-GPT-Plugins) on the Auto-GPT-Plugins GitHub reporistory README page.
 
 ## AutoGPT Configuration
-Set `ALLOWLISTED_PLUGINS=autogpt-api-tools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.
+Set `ALLOWLISTED_PLUGINS=AutoGPTApiTools,example-plugin1,example-plugin2,etc` in your AutoGPT `.env` file.


### PR DESCRIPTION
Auto-GPT takes in the name of the plugin module, e.g. AutoGPTApiTools or AutoGPTEmailPlugin. Hope to save time for debugging!