### PR TITLE
Reduce "command returned too much output" errors in email plugin by truncating output

### DIFF
--- a/src/autogpt_plugins/email/README.md
+++ b/src/autogpt_plugins/email/README.md
@@ -55,6 +55,9 @@ EMAIL_IMAP_SERVER=imap.gmail.com
 EMAIL_MARK_AS_SEEN=False
 EMAIL_SIGNATURE="This was sent by Auto-GPT"
 EMAIL_DRAFT_MODE_WITH_FOLDER=[Gmail]/Drafts
+MAX_CHARACTERS=8000
+MAX_NUM_EMAILS=10
+MAX_EMAIL_CHARACTERS=800
 ```
 
 1. **Email address and password:**
@@ -68,7 +71,9 @@ EMAIL_DRAFT_MODE_WITH_FOLDER=[Gmail]/Drafts
     - `EMAIL_MARK_AS_SEEN`: By default, processed emails are not marked as `SEEN`. Set to `True` to change this.
     - `EMAIL_SIGNATURE`: By default, no email signature is included. Configure this parameter to add a custom signature to each message sent by Auto-GPT.
     - `EMAIL_DRAFT_MODE_WITH_FOLDER`: Prevents emails from being sent and instead stores them as drafts in the specified IMAP folder. `[Gmail]/Drafts` is the default drafts folder for Gmail.
-
+    - `MAX_CHARACTERS`: Character limit for each response for reading emails
+    - `MAX_NUM_EMAILS`: Email count limit for each response for reading emails; only used if MAX_CHARACTERS is breached
+    - `MAX_EMAIL_CHARACTERS`: Character limit for each email's message returned; only used if MAX_CHARACTERS is breached, and MAX_NUM_EMAILS is not
 
 ### 6. Allowlist Plugin
 In your `.env` search for `ALLOWLISTED_PLUGINS` and add this Plugin:


### PR DESCRIPTION
**Motivation:**
As a continuation to the discussion with @riensen in PR https://github.com/Significant-Gravitas/Auto-GPT-Plugins/pull/177, this PR was created as a way to further reduce "command returned too much output" errors in the email plugin by truncating email output based on configuration settings.

**Changes:**
Added truncate_emails function that truncates the email plugin's output based on the following requirements discussed in PR https://github.com/Significant-Gravitas/Auto-GPT-Plugins/pull/177.

```
We set three sensible limits:
MAX_CHARACTERS: The maximum number of characters for all emails retrieved
MAX_NUM_EMAILS: The maximum number of emails
MAX_EMAIL_CHARACTERS: The maximum length per body of each email

If MAX_CHARACTERS is breached, then we check how many emails are retrieved and set a return a smaller list
If the MAX_CHARACTERS is breached while MAX_NUM_EMAILS is not breched, then we start truncating each email which exceeds MAX_EMAIL_CHARACTERS starting with the longest one.
We also need to indicate that emails were truncated to Auto-GPT like adding
```

**Testing:**
Added test to validate email truncation functionality

**Future Work**
Consider whether to use ChatGPT API to summarize emails instead of truncating them.