### PR TITLE
Updating the Telegram plugin with the missing abstract methods

### DIFF
--- a/src/autogpt_plugins/telegram/__init__.py
+++ b/src/autogpt_plugins/telegram/__init__.py
@@ -239,6 +239,12 @@ class AutoGPTTelegram(AutoGPTPluginTemplate):
         """
         pass
 
+    def can_handle_text_embedding(self, text: str) -> bool:
+        return False
+    
+    def handle_text_embedding(self, text: str) -> list:
+        pass
+    
     def can_handle_user_input(self, user_input: str) -> bool:
         
         return True


### PR DESCRIPTION
 Updating the Telegram plugin with the missing abstract methods from the latest AutoGPTPluginTemplate